### PR TITLE
address open uri deperecation warning

### DIFF
--- a/lib/contentstack/api.rb
+++ b/lib/contentstack/api.rb
@@ -54,7 +54,7 @@ module Contentstack
       query = "?" + q.to_query
       # puts "Request URL:- #{@host}#{@api_version}#{path}#{query} \n\n"
       
-      ActiveSupport::JSON.decode(open("#{@host}#{@api_version}#{path}#{query}",
+      ActiveSupport::JSON.decode(URI.open("#{@host}#{@api_version}#{path}#{query}",
       "api_key" =>  @api_key,
       "access_token"=>  @access_token,
       "user_agent"=> "ruby-sdk/#{Contentstack::VERSION}",


### PR DESCRIPTION
Address deprecation warning regarding open uri: https://bugs.ruby-lang.org/issues/15893

Actual warning message:
```
gems/contentstack-0.1.0/lib/contentstack/api.rb:52: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```