### PR TITLE
Updated dependency gem to latest vesrsion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## CHANGELOG
 
+## Version 0.6.2
+### Date: 27th-Feb-2023
+ ### Package Update
+ - Dependency gem update.
+
+------------------------------------------------
 ## Version 0.6.1
 ### Date: 9th-Sept-2022
  ### Bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,28 @@
 ## CHANGELOG
+
+## Version 0.6.1
+### Date: 9th-Sept-2022
+ ### Bug
+ - Live Preview feature for entry with reference update.
+
+------------------------------------------------
+## Version 0.6.0
+### Date: 17th-Aug-2022
+ ### New Features
+ - Proxy and Retry functionality support added.
+
+------------------------------------------------
+## Version 0.5.1
+### Date: 21st-Apr-2022
+ ### Package Update
+ - API request with URI.OPEN issue resolved.
+
+------------------------------------------------
+## Version 0.5.0
+### Date: 8th-Dec-2021
+ ### New Feature
+ - Live Preview feature support added.
+
 ------------------------------------------------
 ## Version 0.4.3
 ### Date: 17th-Sept-2021

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,13 @@ PATH
   remote: .
   specs:
     contentstack (0.6.1)
-      activesupport (>= 3.2, < 6.2)
-      contentstack_utils (~> 1.0, >= 1.0.1)
+      activesupport (>= 3.2, < 7.0.4)
+      contentstack_utils (~> 1.0, >= 1.1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.7)
+    activesupport (6.1.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -16,7 +16,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.0)
     contentstack_utils (1.1.1)
       activesupport (>= 3.2, < 6.2)
       nokogiri (~> 1.11, >= 1.11.0)
@@ -27,13 +27,15 @@ GEM
     hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    mini_portile2 (2.8.0)
-    minitest (5.16.3)
-    nokogiri (1.13.9)
+    mini_portile2 (2.8.1)
+    minitest (5.17.0)
+    nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    public_suffix (5.0.0)
-    racc (1.6.0)
+    nokogiri (1.13.10-x64-mingw32)
+      racc (~> 1.4)
+    public_suffix (5.0.1)
+    racc (1.6.2)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -54,7 +56,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     webmock (3.11.3)
       addressable (>= 2.3.6)
@@ -63,10 +65,11 @@ GEM
     webrick (1.7.0)
     yard (0.9.28)
       webrick (~> 1.7.0)
-    zeitwerk (2.6.6)
+    zeitwerk (2.6.7)
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   contentstack!
@@ -76,4 +79,4 @@ DEPENDENCIES
   yard (~> 0.9.26)
 
 BUNDLED WITH
-   2.1.4
+   2.3.13

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2012-2022 Contentstack. All Rights Reserved
+Copyright (c) 2012-2023 Contentstack. All Rights Reserved
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/contentstack.gemspec
+++ b/contentstack.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency 'activesupport', '>= 3.2', '< 6.2'
+  s.add_dependency 'activesupport', '>= 3.2', '< 7.0.4.2'
   s.add_dependency "contentstack_utils", '~> 1.0', '>= 1.0.1'
   
   s.add_development_dependency 'rspec', '~> 3.10.0'

--- a/contentstack.gemspec
+++ b/contentstack.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'activesupport', '>= 3.2', '< 7.0.4'
-  s.add_dependency "contentstack_utils", '~> 1.0', '>= 1.0.1'
+  s.add_dependency "contentstack_utils", '~> 1.0', '>= 1.1.1'
   
   s.add_development_dependency 'rspec', '~> 3.10.0'
   s.add_development_dependency 'webmock', '~> 3.11.0'

--- a/contentstack.gemspec
+++ b/contentstack.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency 'activesupport', '>= 3.2', '< 7.0.4.2'
+  s.add_dependency 'activesupport', '>= 3.2', '< 7.0.4'
   s.add_dependency "contentstack_utils", '~> 1.0', '>= 1.0.1'
   
   s.add_development_dependency 'rspec', '~> 3.10.0'

--- a/lib/contentstack/version.rb
+++ b/lib/contentstack/version.rb
@@ -1,3 +1,3 @@
 module Contentstack
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end


### PR DESCRIPTION
Upgraded activesupport gem to latest version. Rails 7 requires activesupport
 V7.0 and greater.