### PR TITLE
Upgraded ruby version to 3.2 greater and gem versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## CHANGELOG
 
+## Version 0.8.3
+### Date: 27th-March-2026
+ ### Security and Compatibility
+ - Updated `nokogiri` dependency to `>= 1.19.1` to address the reported vulnerability.
+ - Added `.ruby-version` for Ruby 3.3.11 and aligned gem requirements for modern Ruby/macOS environments.
+ - Added `script/bundle_safe` helper to avoid Bundler OpenSSL MD5 probe crashes on affected Ruby/OpenSSL setups.
+
+------------------------------------------------
+
 ## Version 0.8.2
 ### Date: 12th-January-2026
  ### Improved error messages

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,9 @@
 # Gemfile
 source "https://rubygems.org"
+
+# Transitive via contentstack_utils; pin until upstream requires >= 1.19.1 (SNYK-RUBY-NOKOGIRI-15315717).
+gem "nokogiri", ">= 1.19.1"
+
+# Ruby 4.0.x on recent macOS often segfaults in OpenSSL during `bundle` (not fixable in-app). Use Ruby 3.3+ (see .ruby-version).
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,33 @@
 PATH
   remote: .
   specs:
-    contentstack (0.8.1)
+    contentstack (0.8.3)
       activesupport (>= 3.2)
-      contentstack_utils (~> 1.0)
+      contentstack_utils (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.3)
+    activesupport (8.1.3)
       base64
-      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      json
       logger (>= 1.4.2)
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.8)
+      uri (>= 0.13.1)
+    addressable (2.8.9)
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
-    benchmark (0.5.0)
     bigdecimal (4.0.1)
     concurrent-ruby (1.3.6)
-    connection_pool (2.5.5)
-    contentstack_utils (1.2.1)
+    connection_pool (3.0.2)
+    contentstack_utils (1.2.2)
       activesupport (>= 7.0)
       nokogiri (>= 1.11)
     crack (1.0.1)
@@ -39,28 +39,32 @@ GEM
     hashdiff (1.2.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    json (2.19.3)
     logger (1.7.0)
-    minitest (5.27.0)
-    nokogiri (1.18.10-arm64-darwin)
+    minitest (6.0.2)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    nokogiri (1.19.2-arm64-darwin)
       racc (~> 1.4)
-    public_suffix (6.0.2)
+    prism (1.9.0)
+    public_suffix (7.0.5)
     racc (1.8.1)
     rexml (3.4.4)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.2)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.2)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.3)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.3)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
     securerandom (0.4.1)
-    simplecov (0.21.2)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
@@ -69,8 +73,8 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uri (1.1.1)
-    webmock (3.11.3)
-      addressable (>= 2.3.6)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     yard (0.9.38)
@@ -78,13 +82,15 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-24
+  arm64-darwin-25
 
 DEPENDENCIES
   contentstack!
-  rspec (~> 3.10.0)
-  simplecov (~> 0.21.1)
-  webmock (~> 3.11.0)
-  yard (~> 0.9.26)
+  nokogiri (>= 1.19.1)
+  rspec (~> 3.13.0)
+  simplecov (~> 0.22.0)
+  webmock (~> 3.26.0)
+  yard (~> 0.9.38)
 
 BUNDLED WITH
    2.3.13

--- a/contentstack.gemspec
+++ b/contentstack.gemspec
@@ -9,7 +9,8 @@ Gem::Specification.new do |s|
   s.authors = [%q{Contentstack}]
   s.email = ["support@contentstack.com"]
 
-  s.required_ruby_version = '>= 2.0'
+  # Aligns with nokogiri >= 1.19.x (transitive via contentstack_utils), which requires Ruby >= 3.2.
+  s.required_ruby_version = '>= 3.3'
 
   s.license = "MIT"
   s.homepage = "https://github.com/contentstack/contentstack-ruby"
@@ -21,10 +22,10 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'activesupport', '>= 3.2'
-  s.add_dependency 'contentstack_utils' , '~> 1.0'
+  s.add_dependency 'contentstack_utils' , '~> 1.2'
   
-  s.add_development_dependency 'rspec', '~> 3.10.0'
-  s.add_development_dependency 'webmock', '~> 3.11.0'
-  s.add_development_dependency 'simplecov', '~> 0.21.1'
-  s.add_development_dependency 'yard', '~> 0.9.26'
+  s.add_development_dependency 'rspec', '~> 3.13.0'
+  s.add_development_dependency 'webmock', '~> 3.26.0'
+  s.add_development_dependency 'simplecov', '~> 0.22.0'
+  s.add_development_dependency 'yard', '~> 0.9.38'
 end

--- a/lib/contentstack/version.rb
+++ b/lib/contentstack/version.rb
@@ -1,3 +1,3 @@
 module Contentstack
-  VERSION = "0.8.2"
+  VERSION = "0.8.3"
 end


### PR DESCRIPTION
- Updated `nokogiri` dependency to `>= 1.19.1` to address the reported vulnerability.