### PR TITLE
Fix/snyk fix 03 06 2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## CHANGELOG
 
+## Version 0.9.2
+### Date: 6th-July-2026
+ ### Fix
+ -  - Snyk fixes `json >= 2.19.9`.
+
+------------------------------------------------
+
 ## Version 0.9.1
 ### Date: 29th-June-2026
  ### Fix

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ source "https://rubygems.org"
 # Transitive via contentstack_utils; pin until upstream requires >= 1.19.1 (SNYK-RUBY-NOKOGIRI-15315717).
 gem "nokogiri", ">= 1.19.1"
 
+# Transitive via activesupport; pin until upstream requires >= 2.19.9 (SNYK-RUBY-JSON-17739957).
+gem "json", ">= 2.19.9"
+
 # Ruby 4.0.x on recent macOS often segfaults in OpenSSL during `bundle` (not fixable in-app). Use Ruby 3.3+ (see .ruby-version).
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    contentstack (0.9.1)
+    contentstack (0.9.2)
       activesupport (>= 3.2)
       contentstack_utils (~> 1.2)
 
@@ -119,7 +119,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
-  contentstack (0.9.1)
+  contentstack (0.9.2)
   contentstack_utils (1.2.3) sha256=cf2f5f996eb487559fd2d7d48a99262710f53dec62c84c6e325b9a598cd31ba7
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     hashdiff (1.2.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.19.8)
+    json (2.20.0)
     logger (1.7.0)
     minitest (6.0.6)
       drb (~> 2.0)
@@ -105,6 +105,7 @@ PLATFORMS
 
 DEPENDENCIES
   contentstack!
+  json (>= 2.19.9)
   nokogiri (>= 1.19.1)
   rspec (~> 3.13.0)
   simplecov (~> 0.22.0)
@@ -126,7 +127,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
-  json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
+  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   nokogiri (1.19.3-aarch64-linux-gnu) sha256=46b89e5d7b9e844c2ee360794240c6ea2a4e6fa0c5892a4ed487db621224b639

--- a/lib/contentstack/version.rb
+++ b/lib/contentstack/version.rb
@@ -1,3 +1,3 @@
 module Contentstack
-  VERSION = "0.9.1"
+  VERSION = "0.9.2"
 end


### PR DESCRIPTION
### Changes
- Pinned `json >= 2.19.9` to fix Heap-based Buffer Overflow via `activesupport > json`
- Bundler resolved to `json 2.20.0`
- Version bump `0.9.1` → `0.9.2`

### Snyk Result
✔ No vulnerable paths found (159 tests, 0 failures)